### PR TITLE
feat: add Opus 4.8 pricing

### DIFF
--- a/pricing.json
+++ b/pricing.json
@@ -1,5 +1,6 @@
 {
   "models": {
+    "claude-opus-4-8":   { "input": 5.00,  "output": 25.00, "cache_read": 0.50,  "cache_write_5m": 6.25,   "cache_write_1h": 10.00 },
     "claude-opus-4-7":   { "input": 5.00,  "output": 25.00, "cache_read": 0.50,  "cache_write_5m": 6.25,   "cache_write_1h": 10.00 },
     "claude-opus-4-6":   { "input": 5.00,  "output": 25.00, "cache_read": 0.50,  "cache_write_5m": 6.25,   "cache_write_1h": 10.00 },
     "claude-opus-4-5":   { "input": 5.00,  "output": 25.00, "cache_read": 0.50,  "cache_write_5m": 6.25,   "cache_write_1h": 10.00 },
@@ -17,6 +18,7 @@
     "claude-opus-4-6": { "input": 30.00, "output": 150.00, "cache_read": 3.00, "cache_write_5m": 37.50, "cache_write_1h": 60.00 }
   },
   "families": [
+    { "prefix": "claude-opus-4-8",   "model": "claude-opus-4-8" },
     { "prefix": "claude-opus-4-7",   "model": "claude-opus-4-7" },
     { "prefix": "claude-opus-4-6",   "model": "claude-opus-4-6" },
     { "prefix": "claude-opus-4-5",   "model": "claude-opus-4-5" },
@@ -33,6 +35,7 @@
   ],
   "default_model": "claude-sonnet-4-6",
   "display_names": [
+    { "prefix": "opus-4-8",     "name": "Opus 4.8" },
     { "prefix": "opus-4-7",     "name": "Opus 4.7" },
     { "prefix": "opus-4-6:fast", "name": "Opus 4.6 ⚡" },
     { "prefix": "opus-4-6",     "name": "Opus 4.6" },


### PR DESCRIPTION
## Changes

Adds Opus 4.8 to pricing.json (models, families, display_names), mirroring the Opus 4.7 pattern.