### PR TITLE
refactor: unify walkers and breakdown printers, dedup shared helpers

### DIFF
--- a/format.go
+++ b/format.go
@@ -49,16 +49,21 @@ func fmtDuration(d time.Duration) string {
 	return fmt.Sprintf("%dms", d.Milliseconds())
 }
 
+func toDisplayCurrency(c float64) float64 {
+	if activeCurrency.Rate > 0 {
+		return c * activeCurrency.Rate
+	}
+	return c
+}
+
 func fmtCost(c float64) string {
 	sym := "$"
-	v := c
 	suffix := false
 	if activeCurrency.Rate > 0 {
 		sym = activeCurrency.Symbol
-		v = c * activeCurrency.Rate
 		suffix = activeCurrency.Suffix
 	}
-	num := fmt.Sprintf("%.2f", v)
+	num := fmt.Sprintf("%.2f", toDisplayCurrency(c))
 	if suffix {
 		return num + " " + sym
 	}
@@ -66,10 +71,7 @@ func fmtCost(c float64) string {
 }
 
 func colorize(s string, cost float64) string {
-	c := cost
-	if activeCurrency.Rate > 0 {
-		c = cost * activeCurrency.Rate
-	}
+	c := toDisplayCurrency(cost)
 	switch {
 	case c >= costThresholdRed:
 		return redString(s)
@@ -175,8 +177,10 @@ type jsonModelRow struct {
 	Cost         float64 `json:"cost"`
 }
 
-type jsonDailyRow struct {
-	Date         string  `json:"date"`
+// jsonPeriodRow holds the columns shared by the daily and monthly JSON rows.
+// Each variant embeds it after its own period key, so marshaling keeps the
+// original field order (period first, then these).
+type jsonPeriodRow struct {
 	Model        string  `json:"model"`
 	InputTokens  int     `json:"input_tokens"`
 	OutputTokens int     `json:"output_tokens"`
@@ -186,15 +190,22 @@ type jsonDailyRow struct {
 	Cost         float64 `json:"cost"`
 }
 
+func periodRow(model string, b *Bucket) jsonPeriodRow {
+	return jsonPeriodRow{
+		Model: shortModel(model), InputTokens: b.InputTokens, OutputTokens: b.OutputTokens,
+		CacheRead: b.CacheRead, CacheWrite: b.TotalCacheWrite(),
+		Requests: b.Requests, Cost: b.Cost,
+	}
+}
+
+type jsonDailyRow struct {
+	Date string `json:"date"`
+	jsonPeriodRow
+}
+
 type jsonMonthlyRow struct {
-	Month        string  `json:"month"`
-	Model        string  `json:"model"`
-	InputTokens  int     `json:"input_tokens"`
-	OutputTokens int     `json:"output_tokens"`
-	CacheRead    int     `json:"cache_read_tokens"`
-	CacheWrite   int     `json:"cache_write_tokens"`
-	Requests     int     `json:"requests"`
-	Cost         float64 `json:"cost"`
+	Month string `json:"month"`
+	jsonPeriodRow
 }
 
 type jsonProjectRow struct {
@@ -215,12 +226,7 @@ func buildJSONDaily(data *ParseResult) []jsonDailyRow {
 	var daily []jsonDailyRow
 	for date, dayModels := range data.DailyUsage {
 		for model, b := range dayModels {
-			daily = append(daily, jsonDailyRow{
-				Date: date, Model: shortModel(model),
-				InputTokens: b.InputTokens, OutputTokens: b.OutputTokens,
-				CacheRead: b.CacheRead, CacheWrite: b.TotalCacheWrite(),
-				Requests: b.Requests, Cost: b.Cost,
-			})
+			daily = append(daily, jsonDailyRow{Date: date, jsonPeriodRow: periodRow(model, b)})
 		}
 	}
 	sort.Slice(daily, func(i, j int) bool {
@@ -237,12 +243,7 @@ func buildJSONMonthly(data *ParseResult) []jsonMonthlyRow {
 	var monthly []jsonMonthlyRow
 	for month, monthModels := range monthlyData {
 		for model, b := range monthModels {
-			monthly = append(monthly, jsonMonthlyRow{
-				Month: month, Model: shortModel(model),
-				InputTokens: b.InputTokens, OutputTokens: b.OutputTokens,
-				CacheRead: b.CacheRead, CacheWrite: b.TotalCacheWrite(),
-				Requests: b.Requests, Cost: b.Cost,
-			})
+			monthly = append(monthly, jsonMonthlyRow{Month: month, jsonPeriodRow: periodRow(model, b)})
 		}
 	}
 	sort.Slice(monthly, func(i, j int) bool {
@@ -357,6 +358,21 @@ type modelEntry struct {
 	bucket *Bucket
 }
 
+func printSectionHeader(title string) {
+	bold.Println(strings.Repeat("─", 80))
+	bold.Println("  " + title)
+	bold.Println(strings.Repeat("─", 80))
+}
+
+func sortedByCost(models map[string]*Bucket) []modelEntry {
+	entries := make([]modelEntry, 0, len(models))
+	for name, b := range models {
+		entries = append(entries, modelEntry{name, b})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].bucket.Cost > entries[j].bucket.Cost })
+	return entries
+}
+
 func printSummary(data *ParseResult, opts OutputOptions) {
 	fmt.Println()
 	bold.Println(strings.Repeat("═", 80))
@@ -384,20 +400,14 @@ func printSummary(data *ParseResult, opts OutputOptions) {
 	fmt.Println()
 
 	// Model breakdown
-	bold.Println(strings.Repeat("─", 80))
-	bold.Println("  MODEL BREAKDOWN")
-	bold.Println(strings.Repeat("─", 80))
+	printSectionHeader("MODEL BREAKDOWN")
 	fmt.Printf("  %-16s %9s %9s %9s %9s %7s %10s\n",
 		"Model", "Input", "Output", "Cache R", "Cache W", "Reqs", "Cost")
 	fmt.Println("  " + strings.Repeat("─", 75))
 
 	totals := data.Totals()
 
-	var models []modelEntry
-	for name, b := range data.ModelUsage {
-		models = append(models, modelEntry{name, b})
-	}
-	sort.Slice(models, func(i, j int) bool { return models[i].bucket.Cost > models[j].bucket.Cost })
+	models := sortedByCost(data.ModelUsage)
 
 	for _, m := range models {
 		b := m.bucket
@@ -436,55 +446,56 @@ func printSummary(data *ParseResult, opts OutputOptions) {
 	}
 }
 
-func printDailyBreakdown(data *ParseResult, opts OutputOptions) {
-
-	bold.Println(strings.Repeat("─", 80))
-	bold.Println("  DAILY BREAKDOWN")
-	bold.Println(strings.Repeat("─", 80))
+// printPeriodBreakdown renders a date-bucketed table (daily or monthly). Keys
+// are sorted descending; each key's models sort by cost, the first row carries
+// the period label, and a trailing subtotal row closes the group.
+func printPeriodBreakdown(title, colLabel string, source map[string]map[string]*Bucket, topN int) {
+	printSectionHeader(title)
 	fmt.Printf("  %-12s %-11s %7s %7s %8s %8s %6s %8s\n",
-		"Date", "Model", "Input", "Output", "Cache R", "Cache W", "Reqs", "Cost")
+		colLabel, "Model", "Input", "Output", "Cache R", "Cache W", "Reqs", "Cost")
 	fmt.Println("  " + strings.Repeat("─", 75))
 
-	var dates []string
-	for d := range data.DailyUsage {
-		dates = append(dates, d)
+	var keys []string
+	for k := range source {
+		keys = append(keys, k)
 	}
-	sort.Sort(sort.Reverse(sort.StringSlice(dates)))
-	if opts.TopN > 0 && len(dates) > opts.TopN {
-		dates = dates[:opts.TopN]
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	if topN > 0 && len(keys) > topN {
+		keys = keys[:topN]
 	}
 
-	for _, date := range dates {
-		dayModels := data.DailyUsage[date]
-		var dayCost float64
-		var dayReqs int
+	for _, key := range keys {
+		var cost float64
+		var reqs int
 
-		var sorted []modelEntry
-		for name, b := range dayModels {
-			sorted = append(sorted, modelEntry{name, b})
-			dayCost += b.Cost
-			dayReqs += b.Requests
+		sorted := sortedByCost(source[key])
+		for _, m := range sorted {
+			cost += m.bucket.Cost
+			reqs += m.bucket.Requests
 		}
-		sort.Slice(sorted, func(i, j int) bool { return sorted[i].bucket.Cost > sorted[j].bucket.Cost })
 
 		first := true
 		for _, m := range sorted {
 			b := m.bucket
-			d := ""
+			label := ""
 			if first {
-				d = date
+				label = key
 			}
 			fmt.Printf("  %-12s %s %7s %7s %8s %8s %6d %s\n",
-				d, cyan.Sprintf("%-11s", shortModel(m.name)),
+				label, cyan.Sprintf("%-11s", shortModel(m.name)),
 				fmtTokens(b.InputTokens), fmtTokens(b.OutputTokens),
 				fmtTokens(b.CacheRead), fmtTokens(b.TotalCacheWrite()),
 				b.Requests, colorCost(b.Cost, 8))
 			first = false
 		}
 		fmt.Printf("  %-12s %-11s %7s %7s %8s %8s %6d %s\n",
-			"", "", "", "", "", "", dayReqs, colorCost(dayCost, 8))
+			"", "", "", "", "", "", reqs, colorCost(cost, 8))
 		fmt.Println()
 	}
+}
+
+func printDailyBreakdown(data *ParseResult, opts OutputOptions) {
+	printPeriodBreakdown("DAILY BREAKDOWN", "Date", data.DailyUsage, opts.TopN)
 }
 
 func aggregateMonthly(dailyUsage map[string]map[string]*Bucket) map[string]map[string]*Bucket {
@@ -509,63 +520,40 @@ func aggregateMonthly(dailyUsage map[string]map[string]*Bucket) map[string]map[s
 }
 
 func printMonthlyBreakdown(data *ParseResult, opts OutputOptions) {
+	printPeriodBreakdown("MONTHLY BREAKDOWN", "Month", aggregateMonthly(data.DailyUsage), opts.TopN)
+}
 
-	bold.Println(strings.Repeat("─", 80))
-	bold.Println("  MONTHLY BREAKDOWN")
-	bold.Println(strings.Repeat("─", 80))
-	fmt.Printf("  %-12s %-11s %7s %7s %8s %8s %6s %8s\n",
-		"Month", "Model", "Input", "Output", "Cache R", "Cache W", "Reqs", "Cost")
-	fmt.Println("  " + strings.Repeat("─", 75))
+// printBreakdownGroup renders one named group (a project or a branch): its
+// models sorted by cost, the name wrapped across rows at wrapChunk width within
+// a nameWidth column, then a SUBTOTAL row. Shared by project/branch breakdowns.
+func printBreakdownGroup(name string, models map[string]*Bucket, total float64, nameWidth, wrapChunk int) {
+	sorted := sortedByCost(models)
 
-	monthly := aggregateMonthly(data.DailyUsage)
-
-	var months []string
-	for m := range monthly {
-		months = append(months, m)
-	}
-	sort.Sort(sort.Reverse(sort.StringSlice(months)))
-	if opts.TopN > 0 && len(months) > opts.TopN {
-		months = months[:opts.TopN]
-	}
-
-	for _, month := range months {
-		monthModels := monthly[month]
-		var monthCost float64
-		var monthReqs int
-
-		var sorted []modelEntry
-		for name, b := range monthModels {
-			sorted = append(sorted, modelEntry{name, b})
-			monthCost += b.Cost
-			monthReqs += b.Requests
+	names := wrapName(name, wrapChunk)
+	for i, m := range sorted {
+		n := ""
+		if i < len(names) {
+			n = names[i]
 		}
-		sort.Slice(sorted, func(i, j int) bool { return sorted[i].bucket.Cost > sorted[j].bucket.Cost })
-
-		first := true
-		for _, m := range sorted {
-			b := m.bucket
-			label := ""
-			if first {
-				label = month
-			}
-			fmt.Printf("  %-12s %s %7s %7s %8s %8s %6d %s\n",
-				label, cyan.Sprintf("%-11s", shortModel(m.name)),
-				fmtTokens(b.InputTokens), fmtTokens(b.OutputTokens),
-				fmtTokens(b.CacheRead), fmtTokens(b.TotalCacheWrite()),
-				b.Requests, colorCost(b.Cost, 8))
-			first = false
-		}
-		fmt.Printf("  %-12s %-11s %7s %7s %8s %8s %6d %s\n",
-			"", "", "", "", "", "", monthReqs, colorCost(monthCost, 8))
-		fmt.Println()
+		b := m.bucket
+		fmt.Printf("  %-*s %s %7d %s\n",
+			nameWidth, n, cyan.Sprintf("%-16s", shortModel(m.name)),
+			b.Requests, colorCost(b.Cost, 10))
 	}
+	for i := len(sorted); i < len(names)-1; i++ {
+		fmt.Printf("  %s\n", names[i])
+	}
+	subtotalName := ""
+	if len(names) > len(sorted) {
+		subtotalName = names[len(names)-1]
+	}
+	fmt.Printf("  %-*s %-16s %7s %s\n",
+		nameWidth, subtotalName, "SUBTOTAL", "", colorCost(total, 10))
+	fmt.Println()
 }
 
 func printProjectBreakdown(data *ParseResult, opts OutputOptions) {
-
-	bold.Println(strings.Repeat("─", 80))
-	bold.Println("  PROJECT BREAKDOWN")
-	bold.Println(strings.Repeat("─", 80))
+	printSectionHeader("PROJECT BREAKDOWN")
 	fmt.Printf("  %-35s %-16s %7s %10s\n",
 		"Project", "Model", "Reqs", "Cost")
 	fmt.Println("  " + strings.Repeat("─", 75))
@@ -588,44 +576,13 @@ func printProjectBreakdown(data *ParseResult, opts OutputOptions) {
 	}
 
 	for _, proj := range projects {
-		projModels := data.ProjectUsage[proj.slug]
 		name := displayProject(proj.slug, data.ProjectPaths)
-
-		var sorted []modelEntry
-		for mname, b := range projModels {
-			sorted = append(sorted, modelEntry{mname, b})
-		}
-		sort.Slice(sorted, func(i, j int) bool { return sorted[i].bucket.Cost > sorted[j].bucket.Cost })
-
-		names := wrapName(name, 30)
-		for i, m := range sorted {
-			n := ""
-			if i < len(names) {
-				n = names[i]
-			}
-			b := m.bucket
-			fmt.Printf("  %-35s %s %7d %s\n",
-				n, cyan.Sprintf("%-16s", shortModel(m.name)),
-				b.Requests, colorCost(b.Cost, 10))
-		}
-		for i := len(sorted); i < len(names)-1; i++ {
-			fmt.Printf("  %s\n", names[i])
-		}
-		subtotalName := ""
-		if len(names) > len(sorted) {
-			subtotalName = names[len(names)-1]
-		}
-		fmt.Printf("  %-35s %-16s %7s %s\n",
-			subtotalName, "SUBTOTAL", "", colorCost(proj.total, 10))
-		fmt.Println()
+		printBreakdownGroup(name, data.ProjectUsage[proj.slug], proj.total, 35, 30)
 	}
 }
 
 func printBranchBreakdown(data *ParseResult, opts OutputOptions) {
-
-	bold.Println(strings.Repeat("─", 80))
-	bold.Println("  BRANCH BREAKDOWN")
-	bold.Println(strings.Repeat("─", 80))
+	printSectionHeader("BRANCH BREAKDOWN")
 	fmt.Printf("  %-30s %-16s %7s %10s\n",
 		"Branch", "Model", "Reqs", "Cost")
 	fmt.Println("  " + strings.Repeat("─", 75))
@@ -650,34 +607,7 @@ func printBranchBreakdown(data *ParseResult, opts OutputOptions) {
 		}
 
 		for _, br := range branchList {
-			models := branchMap[br.branch]
-			var sorted []modelEntry
-			for mname, b := range models {
-				sorted = append(sorted, modelEntry{mname, b})
-			}
-			sort.Slice(sorted, func(i, j int) bool { return sorted[i].bucket.Cost > sorted[j].bucket.Cost })
-
-			names := wrapName(br.branch, 25)
-			for i, m := range sorted {
-				n := ""
-				if i < len(names) {
-					n = names[i]
-				}
-				b := m.bucket
-				fmt.Printf("  %-30s %s %7d %s\n",
-					n, cyan.Sprintf("%-16s", shortModel(m.name)),
-					b.Requests, colorCost(b.Cost, 10))
-			}
-			for i := len(sorted); i < len(names)-1; i++ {
-				fmt.Printf("  %s\n", names[i])
-			}
-			subtotalName := ""
-			if len(names) > len(sorted) {
-				subtotalName = names[len(names)-1]
-			}
-			fmt.Printf("  %-30s %-16s %7s %s\n",
-				subtotalName, "SUBTOTAL", "", colorCost(br.total, 10))
-			fmt.Println()
+			printBreakdownGroup(br.branch, branchMap[br.branch], br.total, 30, 25)
 		}
 	}
 	fmt.Println()

--- a/format.go
+++ b/format.go
@@ -14,6 +14,17 @@ var (
 	costThresholdYellow = 25.0
 )
 
+// sortAndTrim sorts s in place by less (which should express the desired
+// ordering, e.g. higher-cost-first) and returns at most topN elements.
+// A topN of 0 (or negative) keeps all of them.
+func sortAndTrim[T any](s []T, less func(a, b T) bool, topN int) []T {
+	sort.Slice(s, func(i, j int) bool { return less(s[i], s[j]) })
+	if topN > 0 && len(s) > topN {
+		return s[:topN]
+	}
+	return s
+}
+
 func fmtCount(n int) string {
 	s := fmt.Sprintf("%d", n)
 	if len(s) <= 3 {
@@ -229,13 +240,12 @@ func buildJSONDaily(data *ParseResult) []jsonDailyRow {
 			daily = append(daily, jsonDailyRow{Date: date, jsonPeriodRow: periodRow(model, b)})
 		}
 	}
-	sort.Slice(daily, func(i, j int) bool {
-		if daily[i].Date != daily[j].Date {
-			return daily[i].Date > daily[j].Date
+	return sortAndTrim(daily, func(a, b jsonDailyRow) bool {
+		if a.Date != b.Date {
+			return a.Date > b.Date
 		}
-		return daily[i].Cost > daily[j].Cost
-	})
-	return daily
+		return a.Cost > b.Cost
+	}, 0)
 }
 
 func buildJSONMonthly(data *ParseResult) []jsonMonthlyRow {
@@ -246,13 +256,12 @@ func buildJSONMonthly(data *ParseResult) []jsonMonthlyRow {
 			monthly = append(monthly, jsonMonthlyRow{Month: month, jsonPeriodRow: periodRow(model, b)})
 		}
 	}
-	sort.Slice(monthly, func(i, j int) bool {
-		if monthly[i].Month != monthly[j].Month {
-			return monthly[i].Month > monthly[j].Month
+	return sortAndTrim(monthly, func(a, b jsonMonthlyRow) bool {
+		if a.Month != b.Month {
+			return a.Month > b.Month
 		}
-		return monthly[i].Cost > monthly[j].Cost
-	})
-	return monthly
+		return a.Cost > b.Cost
+	}, 0)
 }
 
 func buildJSONProjects(data *ParseResult) []jsonProjectRow {
@@ -262,8 +271,7 @@ func buildJSONProjects(data *ParseResult) []jsonProjectRow {
 			projects = append(projects, jsonProjectRow{Project: displayProject(slug, data.ProjectPaths), Model: shortModel(model), Requests: b.Requests, Cost: b.Cost})
 		}
 	}
-	sort.Slice(projects, func(i, j int) bool { return projects[i].Cost > projects[j].Cost })
-	return projects
+	return sortAndTrim(projects, func(a, b jsonProjectRow) bool { return a.Cost > b.Cost }, 0)
 }
 
 func buildJSONBranches(data *ParseResult) []jsonBranchRow {
@@ -278,8 +286,7 @@ func buildJSONBranches(data *ParseResult) []jsonBranchRow {
 			}
 		}
 	}
-	sort.Slice(branches, func(i, j int) bool { return branches[i].Cost > branches[j].Cost })
-	return branches
+	return sortAndTrim(branches, func(a, b jsonBranchRow) bool { return a.Cost > b.Cost }, 0)
 }
 
 func printJSON(data *ParseResult, opts OutputOptions) {
@@ -294,7 +301,7 @@ func printJSON(data *ParseResult, opts OutputOptions) {
 			CacheWrite1h: b.CacheWrite1h, Requests: b.Requests, Cost: b.Cost,
 		})
 	}
-	sort.Slice(models, func(i, j int) bool { return models[i].Cost > models[j].Cost })
+	models = sortAndTrim(models, func(a, b jsonModelRow) bool { return a.Cost > b.Cost }, 0)
 
 	out := struct {
 		Summary  interface{} `json:"summary"`
@@ -369,8 +376,7 @@ func sortedByCost(models map[string]*Bucket) []modelEntry {
 	for name, b := range models {
 		entries = append(entries, modelEntry{name, b})
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].bucket.Cost > entries[j].bucket.Cost })
-	return entries
+	return sortAndTrim(entries, func(a, b modelEntry) bool { return a.bucket.Cost > b.bucket.Cost }, 0)
 }
 
 func printSummary(data *ParseResult, opts OutputOptions) {
@@ -459,10 +465,7 @@ func printPeriodBreakdown(title, colLabel string, source map[string]map[string]*
 	for k := range source {
 		keys = append(keys, k)
 	}
-	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
-	if topN > 0 && len(keys) > topN {
-		keys = keys[:topN]
-	}
+	keys = sortAndTrim(keys, func(a, b string) bool { return a > b }, topN)
 
 	for _, key := range keys {
 		var cost float64
@@ -570,10 +573,7 @@ func printProjectBreakdown(data *ParseResult, opts OutputOptions) {
 		}
 		projects = append(projects, projTotal{slug, t})
 	}
-	sort.Slice(projects, func(i, j int) bool { return projects[i].total > projects[j].total })
-	if opts.TopN > 0 && len(projects) > opts.TopN {
-		projects = projects[:opts.TopN]
-	}
+	projects = sortAndTrim(projects, func(a, b projTotal) bool { return a.total > b.total }, opts.TopN)
 
 	for _, proj := range projects {
 		name := displayProject(proj.slug, data.ProjectPaths)
@@ -601,10 +601,7 @@ func printBranchBreakdown(data *ParseResult, opts OutputOptions) {
 			}
 			branchList = append(branchList, branchTotal{br, bt})
 		}
-		sort.Slice(branchList, func(i, j int) bool { return branchList[i].total > branchList[j].total })
-		if opts.TopN > 0 && len(branchList) > opts.TopN {
-			branchList = branchList[:opts.TopN]
-		}
+		branchList = sortAndTrim(branchList, func(a, b branchTotal) bool { return a.total > b.total }, opts.TopN)
 
 		for _, br := range branchList {
 			printBreakdownGroup(br.branch, branchMap[br.branch], br.total, 30, 25)
@@ -704,10 +701,7 @@ func printAgentBreakdown(data *ToolResult, topN int) {
 	for name, count := range data.AgentCounts {
 		agents = append(agents, agentEntry{name, count, data.AgentTotalTime[name], len(data.AgentProjects[name])})
 	}
-	sort.Slice(agents, func(i, j int) bool { return agents[i].count > agents[j].count })
-	if topN > 0 && len(agents) > topN {
-		agents = agents[:topN]
-	}
+	agents = sortAndTrim(agents, func(a, b agentEntry) bool { return a.count > b.count }, topN)
 
 	for _, a := range agents {
 		avgStr := "-"
@@ -752,10 +746,7 @@ func printSkillBreakdown(data *ToolResult, topN int) {
 	for name, count := range data.SkillCounts {
 		skills = append(skills, toolEntry{name: name, count: count, projs: len(data.SkillProjects[name])})
 	}
-	sort.Slice(skills, func(i, j int) bool { return skills[i].count > skills[j].count })
-	if topN > 0 && len(skills) > topN {
-		skills = skills[:topN]
-	}
+	skills = sortAndTrim(skills, func(a, b toolEntry) bool { return a.count > b.count }, topN)
 
 	for _, s := range skills {
 		names := wrapName(s.name, 44)
@@ -800,10 +791,7 @@ func printToolUsage(data *ToolResult, topN int) {
 	for name, count := range data.ToolCounts {
 		tools = append(tools, toolEntry{name, count, data.ToolErrors[name], len(data.ToolProjects[name])})
 	}
-	sort.Slice(tools, func(i, j int) bool { return tools[i].count > tools[j].count })
-	if topN > 0 && len(tools) > topN {
-		tools = tools[:topN]
-	}
+	tools = sortAndTrim(tools, func(a, b toolEntry) bool { return a.count > b.count }, topN)
 
 	for _, t := range tools {
 		errStr := "-"
@@ -852,19 +840,13 @@ func printToolsJSON(data *ToolResult, topN int) {
 		}
 		tools = append(tools, jsonToolRow{name, count, errs, rate, len(data.ToolProjects[name])})
 	}
-	sort.Slice(tools, func(i, j int) bool { return tools[i].Invocations > tools[j].Invocations })
-	if topN > 0 && len(tools) > topN {
-		tools = tools[:topN]
-	}
+	tools = sortAndTrim(tools, func(a, b jsonToolRow) bool { return a.Invocations > b.Invocations }, topN)
 
 	var skills []jsonSkillRow
 	for name, count := range data.SkillCounts {
 		skills = append(skills, jsonSkillRow{name, count, len(data.SkillProjects[name])})
 	}
-	sort.Slice(skills, func(i, j int) bool { return skills[i].Invocations > skills[j].Invocations })
-	if topN > 0 && len(skills) > topN {
-		skills = skills[:topN]
-	}
+	skills = sortAndTrim(skills, func(a, b jsonSkillRow) bool { return a.Invocations > b.Invocations }, topN)
 
 	var agents []jsonAgentRow
 	for name, count := range data.AgentCounts {
@@ -875,10 +857,7 @@ func printToolsJSON(data *ToolResult, topN int) {
 		}
 		agents = append(agents, jsonAgentRow{name, count, avgMs, totalMs, len(data.AgentProjects[name])})
 	}
-	sort.Slice(agents, func(i, j int) bool { return agents[i].Invocations > agents[j].Invocations })
-	if topN > 0 && len(agents) > topN {
-		agents = agents[:topN]
-	}
+	agents = sortAndTrim(agents, func(a, b jsonAgentRow) bool { return a.Invocations > b.Invocations }, topN)
 
 	unused := unusedSkills(data)
 

--- a/format_test.go
+++ b/format_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -284,5 +288,127 @@ func TestAggregateMonthlyTokens(t *testing.T) {
 	}
 	if b.CacheWrite1h != 45 {
 		t.Errorf("CacheWrite1h = %d, want 45", b.CacheWrite1h)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	_ = w.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	return buf.String()
+}
+
+func fixtureData(t *testing.T) *ParseResult {
+	t.Helper()
+	data, err := parseLogs("testdata", 0, "")
+	if err != nil {
+		t.Fatalf("parseLogs: %v", err)
+	}
+	return data
+}
+
+func assertContainsAll(t *testing.T, got string, want ...string) {
+	t.Helper()
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("output missing %q\n--- output ---\n%s", w, got)
+		}
+	}
+}
+
+func TestPrintDailyBreakdown(t *testing.T) {
+	noColorFlag = true
+	defer func() { noColorFlag = false }()
+
+	data := fixtureData(t)
+	out := captureStdout(t, func() { printDailyBreakdown(data, OutputOptions{ShowDaily: true}) })
+
+	assertContainsAll(t, out, "DAILY BREAKDOWN", "Date", "2026-02-18", "2026-02-19", "Opus 4.6", "Haiku 4.5")
+	// Two days, each ending in a subtotal row (blank label + cost).
+	if n := strings.Count(out, "$"); n < 2 {
+		t.Errorf("expected cost figures in daily breakdown, got %d $ signs", n)
+	}
+}
+
+func TestPrintMonthlyBreakdown(t *testing.T) {
+	noColorFlag = true
+	defer func() { noColorFlag = false }()
+
+	data := fixtureData(t)
+	out := captureStdout(t, func() { printMonthlyBreakdown(data, OutputOptions{ShowMonthly: true}) })
+
+	assertContainsAll(t, out, "MONTHLY BREAKDOWN", "Month", "2026-02", "Opus 4.6", "Haiku 4.5")
+}
+
+func TestPrintProjectBreakdown(t *testing.T) {
+	noColorFlag = true
+	defer func() { noColorFlag = false }()
+
+	data := fixtureData(t)
+	name := displayProject("C--Users-alice-git-webapp", data.ProjectPaths)
+	out := captureStdout(t, func() { printProjectBreakdown(data, OutputOptions{ShowProjects: true}) })
+
+	assertContainsAll(t, out, "PROJECT BREAKDOWN", "Project", name, "Opus 4.6", "Haiku 4.5", "SUBTOTAL")
+}
+
+func TestPrintBranchBreakdown(t *testing.T) {
+	noColorFlag = true
+	defer func() { noColorFlag = false }()
+
+	data := fixtureData(t)
+	out := captureStdout(t, func() { printBranchBreakdown(data, OutputOptions{ShowBranches: true}) })
+
+	assertContainsAll(t, out, "BRANCH BREAKDOWN", "Branch", "main", "Opus 4.6", "Haiku 4.5", "SUBTOTAL")
+}
+
+func TestPrintDailyBreakdown_TopN(t *testing.T) {
+	noColorFlag = true
+	defer func() { noColorFlag = false }()
+
+	data := fixtureData(t)
+	out := captureStdout(t, func() { printDailyBreakdown(data, OutputOptions{ShowDaily: true, TopN: 1}) })
+
+	// TopN=1 keeps only the most recent day.
+	if strings.Contains(out, "2026-02-18") {
+		t.Errorf("TopN=1 should drop the older day\n%s", out)
+	}
+	assertContainsAll(t, out, "2026-02-19")
+}
+
+func TestBuildJSONDaily(t *testing.T) {
+	data := fixtureData(t)
+	rows := buildJSONDaily(data)
+	if len(rows) == 0 {
+		t.Fatal("expected daily rows")
+	}
+	// Sorted by date descending, then cost descending.
+	for i := 1; i < len(rows); i++ {
+		if rows[i-1].Date < rows[i].Date {
+			t.Errorf("rows not date-descending at %d: %s < %s", i, rows[i-1].Date, rows[i].Date)
+		}
+	}
+}
+
+func TestBuildJSONMonthly(t *testing.T) {
+	data := fixtureData(t)
+	rows := buildJSONMonthly(data)
+	if len(rows) == 0 {
+		t.Fatal("expected monthly rows")
+	}
+	for _, r := range rows {
+		if r.Month != "2026-02" {
+			t.Errorf("unexpected month %q", r.Month)
+		}
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,11 +58,26 @@ type dedupRecord struct {
 	Timestamp time.Time
 }
 
+func hasJSONType(line []byte, typ string) bool {
+	return bytes.Contains(line, []byte(`"type":"`+typ+`"`)) ||
+		bytes.Contains(line, []byte(`"type": "`+typ+`"`))
+}
+
 func fastSuffix(speed string) string {
 	if speed == "fast" {
 		return ":fast"
 	}
 	return ""
+}
+
+// localMidnightCutoff returns the local-midnight start of the days-long window
+// (inclusive of today), and whether a cutoff applies at all.
+func localMidnightCutoff(days int) (cutoff time.Time, hasCutoff bool) {
+	if days <= 0 {
+		return time.Time{}, false
+	}
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -(days - 1)), true
 }
 
 func captureCwd(paths map[string]string, slug, cwd string) {
@@ -107,7 +121,7 @@ func parseFile(path string, cutoff time.Time, hasCutoff bool, projectSlug string
 			continue
 		}
 
-		if !bytes.Contains(line, []byte(`"type":"assistant"`)) && !bytes.Contains(line, []byte(`"type": "assistant"`)) {
+		if !hasJSONType(line, "assistant") {
 			continue
 		}
 
@@ -162,70 +176,18 @@ func parseFile(path string, cutoff time.Time, hasCutoff bool, projectSlug string
 	return rawCount, parseErrs, nil
 }
 
-type logWalker struct {
-	projectsDir  string
-	matchedSlug  string
-	hasCutoff    bool
-	cutoff       time.Time
-	deduped      map[string]*dedupRecord
-	projectPaths map[string]string
-	totalFiles   int
-	parseErrors  int
-}
-
-func (w *logWalker) walk(path string, d fs.DirEntry, err error) error {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-		return nil
+func newParseResult() *ParseResult {
+	return &ParseResult{
+		ModelUsage:   make(map[string]*Bucket),
+		DailyUsage:   make(map[string]map[string]*Bucket),
+		ProjectUsage: make(map[string]map[string]*Bucket),
+		BranchUsage:  make(map[string]map[string]map[string]*Bucket),
+		ProjectPaths: make(map[string]string),
 	}
-
-	if d.IsDir() {
-		if path == w.projectsDir {
-			return nil
-		}
-		if w.matchedSlug != "" {
-			rel, _ := filepath.Rel(w.projectsDir, path)
-			slug := strings.SplitN(rel, string(filepath.Separator), 2)[0]
-			if slug != w.matchedSlug {
-				return fs.SkipDir
-			}
-		}
-		return nil
-	}
-
-	if !strings.HasSuffix(path, ".jsonl") {
-		return nil
-	}
-
-	if w.hasCutoff {
-		if info, err := d.Info(); err == nil && info.ModTime().Before(w.cutoff) {
-			return nil
-		}
-	}
-
-	rel, err := filepath.Rel(w.projectsDir, path)
-	if err != nil {
-		return nil
-	}
-	parts := strings.SplitN(rel, string(filepath.Separator), 2)
-	projectSlug := parts[0]
-
-	w.totalFiles++
-	_, pErr, fErr := parseFile(path, w.cutoff, w.hasCutoff, projectSlug, w.deduped, w.projectPaths)
-	if fErr != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not read %s: %v\n", path, fErr)
-		return nil
-	}
-	w.parseErrors += pErr
-	return nil
 }
 
 func parseLogs(baseDir string, days int, projectFilter string) (*ParseResult, error) {
-	var cutoff time.Time
-	if days > 0 {
-		now := time.Now()
-		cutoff = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -(days - 1))
-	}
+	cutoff, hasCutoff := localMidnightCutoff(days)
 
 	projectsDir := filepath.Join(baseDir, "projects")
 	if info, err := os.Stat(projectsDir); err != nil || !info.IsDir() {
@@ -234,40 +196,39 @@ func parseLogs(baseDir string, days int, projectFilter string) (*ParseResult, er
 
 	matchedSlug := resolveProjectSlug(projectsDir, projectFilter)
 	if projectFilter != "" && matchedSlug == "" {
-		return &ParseResult{
-			ModelUsage:   make(map[string]*Bucket),
-			DailyUsage:   make(map[string]map[string]*Bucket),
-			ProjectUsage: make(map[string]map[string]*Bucket),
-			BranchUsage:  make(map[string]map[string]map[string]*Bucket),
-			ProjectPaths: make(map[string]string),
-		}, nil
+		return newParseResult(), nil
 	}
 
-	w := &logWalker{
-		projectsDir:  projectsDir,
-		matchedSlug:  matchedSlug,
-		hasCutoff:    days > 0,
-		cutoff:       cutoff,
-		deduped:      make(map[string]*dedupRecord),
-		projectPaths: make(map[string]string),
+	deduped := make(map[string]*dedupRecord)
+	projectPaths := make(map[string]string)
+	var parseErrors int
+
+	w := &dirWalker{
+		projectsDir: projectsDir,
+		matchedSlug: matchedSlug,
+		hasCutoff:   hasCutoff,
+		cutoff:      cutoff,
+		onFile: func(path, projectSlug, _ string) {
+			_, pErr, fErr := parseFile(path, cutoff, hasCutoff, projectSlug, deduped, projectPaths)
+			if fErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not read %s: %v\n", path, fErr)
+				return
+			}
+			parseErrors += pErr
+		},
 	}
 
 	if err := filepath.WalkDir(projectsDir, w.walk); err != nil {
 		return nil, err
 	}
 
-	result := &ParseResult{
-		ModelUsage:   make(map[string]*Bucket),
-		DailyUsage:   make(map[string]map[string]*Bucket),
-		ProjectUsage: make(map[string]map[string]*Bucket),
-		BranchUsage:  make(map[string]map[string]map[string]*Bucket),
-		ProjectPaths: w.projectPaths,
-		TotalFiles:   w.totalFiles,
-		TotalRecords: len(w.deduped),
-		ParseErrors:  w.parseErrors,
-	}
+	result := newParseResult()
+	result.ProjectPaths = projectPaths
+	result.TotalFiles = w.totalFiles
+	result.TotalRecords = len(deduped)
+	result.ParseErrors = parseErrors
 
-	for _, r := range w.deduped {
+	for _, r := range deduped {
 		cr := calcCostResult(r.Model, r.Usage)
 		cache5m, cache1h := r.Usage.CacheWriteTokens()
 

--- a/statusline.go
+++ b/statusline.go
@@ -56,11 +56,6 @@ type StatuslineInput struct {
 	} `json:"workspace"`
 }
 
-// formatFiveHourUsage is kept for backward compatibility with tests.
-func formatFiveHourUsage(usedPct float64, resetsAt int64, now time.Time) string {
-	return formatRateLimitUsage(usedPct, resetsAt, now, fiveHourWindow, fiveHourLowBattery)
-}
-
 func readStatuslineInput(r io.Reader) (*StatuslineInput, error) {
 	var input StatuslineInput
 	if err := json.NewDecoder(r).Decode(&input); err != nil {
@@ -118,10 +113,6 @@ func sessionBranch(deduped map[string]*dedupRecord) string {
 		}
 	}
 	return branch
-}
-
-func formatStatusline(sCost, tCost float64, input *StatuslineInput, mcpNames []string, branch string) string {
-	return formatStatuslineWithConfig(sCost, tCost, input, mcpNames, branch, nil)
 }
 
 func formatStatuslineWithConfig(sCost, tCost float64, input *StatuslineInput, mcpNames []string, branch string, cfg *StatuslineConfig) string {

--- a/statusline_config_test.go
+++ b/statusline_config_test.go
@@ -362,21 +362,6 @@ func TestFormatStatuslineWithConfig_LineBreak(t *testing.T) {
 	}
 }
 
-func TestFormatStatuslineWithConfig_NilConfigMatchesDefault(t *testing.T) {
-	noColorFlag = true
-	defer func() { noColorFlag = false }()
-
-	input := &StatuslineInput{}
-	input.Model.ID = "claude-opus-4-6"
-	input.ContextWindow.UsedPercentage = 45.0
-
-	got1 := formatStatusline(0.50, 2.00, input, nil, "")
-	got2 := formatStatuslineWithConfig(0.50, 2.00, input, nil, "", nil)
-	if got1 != got2 {
-		t.Errorf("nil config differs from default:\n  formatStatusline:           %q\n  formatStatuslineWithConfig: %q", got1, got2)
-	}
-}
-
 func TestFormatStatuslineWithConfig_UnknownSegmentIgnored(t *testing.T) {
 	noColorFlag = true
 	defer func() { noColorFlag = false }()
@@ -503,20 +488,6 @@ func TestFormatRateLimitUsage_SevenDay(t *testing.T) {
 	}
 	if !strings.Contains(got, "/7d") {
 		t.Errorf("got %q, expected /7d label", got)
-	}
-}
-
-func TestFormatRateLimitUsage_BackwardCompatible5h(t *testing.T) {
-	noColorFlag = true
-	defer func() { noColorFlag = false }()
-
-	now := time.Date(2026, 3, 25, 11, 30, 0, 0, time.UTC)
-	resetsAt := time.Date(2026, 3, 25, 15, 0, 0, 0, time.UTC).Unix()
-
-	oldResult := formatFiveHourUsage(6, resetsAt, now)
-	newResult := formatRateLimitUsage(6, resetsAt, now, fiveHourWindow, fiveHourLowBattery)
-	if oldResult != newResult {
-		t.Errorf("backward compat broken:\n  old: %q\n  new: %q", oldResult, newResult)
 	}
 }
 

--- a/statusline_test.go
+++ b/statusline_test.go
@@ -136,7 +136,7 @@ func TestFormatFiveHourUsage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatFiveHourUsage(tt.pct, tt.resetsAt, tt.now)
+			got := formatRateLimitUsage(tt.pct, tt.resetsAt, tt.now, fiveHourWindow, fiveHourLowBattery)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
@@ -337,7 +337,7 @@ func TestFormatStatusline(t *testing.T) {
 			input.Model.ID = tt.modelID
 			input.ContextWindow.UsedPercentage = tt.ctxPct
 
-			result := formatStatusline(tt.sCost, tt.tCost, input, nil, "")
+			result := formatStatuslineWithConfig(tt.sCost, tt.tCost, input, nil, "", nil)
 			for _, sub := range tt.wantSub {
 				if !strings.Contains(result, sub) {
 					t.Errorf("output %q missing substring %q", result, sub)
@@ -363,7 +363,7 @@ func TestFormatStatusline_With5h(t *testing.T) {
 		UsedPercentage: 6, ResetsAt: time.Now().Add(2 * time.Hour).Unix(),
 	}
 
-	result := formatStatusline(1.35, 1.98, input, nil, "")
+	result := formatStatuslineWithConfig(1.35, 1.98, input, nil, "", nil)
 	if !strings.Contains(result, "🔋 94%") {
 		t.Errorf("output %q missing 5h battery segment", result)
 	}
@@ -384,7 +384,7 @@ func TestFormatStatusline_No5h(t *testing.T) {
 	input.ContextWindow.UsedPercentage = 45.0
 	// RateLimits.FiveHour is nil (API billing)
 
-	result := formatStatusline(0.50, 2.00, input, nil, "")
+	result := formatStatuslineWithConfig(0.50, 2.00, input, nil, "", nil)
 	if strings.Contains(result, "🔋") || strings.Contains(result, "🪫") {
 		t.Errorf("output %q should not contain battery when FiveHour is nil", result)
 	}
@@ -398,7 +398,7 @@ func TestFormatStatusline_WithMCPs(t *testing.T) {
 	input.Model.ID = "claude-opus-4-6"
 	input.ContextWindow.UsedPercentage = 45.0
 
-	result := formatStatusline(0.50, 2.00, input, []string{"github", "jira", "slack"}, "")
+	result := formatStatuslineWithConfig(0.50, 2.00, input, []string{"github", "jira", "slack"}, "", nil)
 	if !strings.Contains(result, "🔌 3 MCPs (github, jira, slack)") {
 		t.Errorf("output %q missing MCP section", result)
 	}
@@ -415,7 +415,7 @@ func TestFormatStatusline_SingleMCP(t *testing.T) {
 	input.Model.ID = "claude-opus-4-6"
 	input.ContextWindow.UsedPercentage = 45.0
 
-	result := formatStatusline(0.50, 2.00, input, []string{"context7"}, "")
+	result := formatStatuslineWithConfig(0.50, 2.00, input, []string{"context7"}, "", nil)
 	if !strings.Contains(result, "🔌 1 MCP (context7)") {
 		t.Errorf("output %q missing singular MCP section", result)
 	}
@@ -429,12 +429,12 @@ func TestFormatStatusline_NoMCPs(t *testing.T) {
 	input.Model.ID = "claude-opus-4-6"
 	input.ContextWindow.UsedPercentage = 45.0
 
-	result := formatStatusline(0.50, 2.00, input, nil, "")
+	result := formatStatuslineWithConfig(0.50, 2.00, input, nil, "", nil)
 	if strings.Contains(result, "🔌") {
 		t.Errorf("output %q should not contain MCP section when no MCPs", result)
 	}
 
-	result2 := formatStatusline(0.50, 2.00, input, []string{}, "")
+	result2 := formatStatuslineWithConfig(0.50, 2.00, input, []string{}, "", nil)
 	if strings.Contains(result2, "🔌") {
 		t.Errorf("output %q should not contain MCP section for empty slice", result2)
 	}
@@ -449,7 +449,7 @@ func TestFormatStatusline_ManyMCPsTruncated(t *testing.T) {
 	input.ContextWindow.UsedPercentage = 45.0
 
 	mcps := []string{"asana", "context7", "firebase", "github", "jira"}
-	result := formatStatusline(0.50, 2.00, input, mcps, "")
+	result := formatStatuslineWithConfig(0.50, 2.00, input, mcps, "", nil)
 	if !strings.Contains(result, "🔌 5 MCPs (asana, context7, firebase, ...)") {
 		t.Errorf("output %q missing truncated MCP section", result)
 	}

--- a/tools.go
+++ b/tools.go
@@ -142,7 +142,10 @@ func parseSkillListing(content string) []string {
 		}
 		line = strings.TrimPrefix(line, "- ")
 		if idx := strings.Index(line, ": "); idx > 0 {
-			skills = append(skills, line[:idx])
+			line = line[:idx]
+		}
+		if line = strings.TrimSpace(line); line != "" {
+			skills = append(skills, line)
 		}
 	}
 	return skills

--- a/tools.go
+++ b/tools.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,6 +61,22 @@ type toolCollector struct {
 	agentUseTS     map[string]time.Time // tool_use_id → timestamp (Agent calls)
 	agentUseType   map[string]string    // tool_use_id → agent type
 	agentTotalTime map[string]time.Duration
+}
+
+func newToolResult() *ToolResult {
+	return &ToolResult{
+		ToolCounts:     make(map[string]int),
+		ToolErrors:     make(map[string]int),
+		SkillCounts:    make(map[string]int),
+		AgentCounts:    make(map[string]int),
+		AgentTotalTime: make(map[string]time.Duration),
+		ToolProjects:   make(map[string]map[string]bool),
+		SkillProjects:  make(map[string]map[string]bool),
+		AgentProjects:  make(map[string]map[string]bool),
+		ToolSessions:   make(map[string]bool),
+		AgentSessions:  make(map[string]bool),
+		SkillSessions:  make(map[string]bool),
+	}
 }
 
 func newToolCollector() *toolCollector {
@@ -244,16 +259,12 @@ func (col *toolCollector) processSkillListing(rec *toolRecord) {
 }
 
 func isToolLine(line []byte) bool {
-	isAssistant := bytes.Contains(line, []byte(`"type":"assistant"`)) || bytes.Contains(line, []byte(`"type": "assistant"`))
-	if isAssistant {
+	switch {
+	case hasJSONType(line, "assistant"):
 		return bytes.Contains(line, []byte(`"tool_use"`))
-	}
-	isUser := bytes.Contains(line, []byte(`"type":"user"`)) || bytes.Contains(line, []byte(`"type": "user"`))
-	if isUser {
+	case hasJSONType(line, "user"):
 		return bytes.Contains(line, []byte(`"tool_result"`))
-	}
-	isAttachment := bytes.Contains(line, []byte(`"type":"attachment"`)) || bytes.Contains(line, []byte(`"type": "attachment"`))
-	if isAttachment {
+	case hasJSONType(line, "attachment"):
 		return bytes.Contains(line, []byte(`"skill_listing"`))
 	}
 	return false
@@ -321,75 +332,8 @@ func parseToolFile(path string, cutoff time.Time, hasCutoff bool, projectSlug, s
 	return parseErrs, nil
 }
 
-type toolWalker struct {
-	projectsDir string
-	matchedSlug string
-	hasCutoff   bool
-	cutoff      time.Time
-	col         *toolCollector
-	totalFiles  int
-	parseErrors int
-}
-
-func (w *toolWalker) walk(path string, d fs.DirEntry, err error) error {
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-		return nil
-	}
-
-	if d.IsDir() {
-		if path == w.projectsDir {
-			return nil
-		}
-		if w.matchedSlug != "" {
-			rel, _ := filepath.Rel(w.projectsDir, path)
-			slug := strings.SplitN(rel, string(filepath.Separator), 2)[0]
-			if slug != w.matchedSlug {
-				return fs.SkipDir
-			}
-		}
-		return nil
-	}
-
-	if !strings.HasSuffix(path, ".jsonl") {
-		return nil
-	}
-
-	if w.hasCutoff {
-		if info, err := d.Info(); err == nil && info.ModTime().Before(w.cutoff) {
-			return nil
-		}
-	}
-
-	rel, err := filepath.Rel(w.projectsDir, path)
-	if err != nil {
-		return nil
-	}
-	parts := strings.SplitN(rel, string(filepath.Separator), 2)
-	projectSlug := parts[0]
-
-	sessionID := ""
-	if len(parts) > 1 {
-		sessionParts := strings.SplitN(parts[1], string(filepath.Separator), 2)
-		sessionID = strings.TrimSuffix(sessionParts[0], ".jsonl")
-	}
-
-	w.totalFiles++
-	pErr, fErr := parseToolFile(path, w.cutoff, w.hasCutoff, projectSlug, sessionID, w.col)
-	if fErr != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not read %s: %v\n", path, fErr)
-		return nil
-	}
-	w.parseErrors += pErr
-	return nil
-}
-
 func parseTools(baseDir string, days int, projectFilter string) (*ToolResult, error) {
-	var cutoff time.Time
-	if days > 0 {
-		now := time.Now()
-		cutoff = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -(days - 1))
-	}
+	cutoff, hasCutoff := localMidnightCutoff(days)
 
 	projectsDir := filepath.Join(baseDir, "projects")
 	if info, err := os.Stat(projectsDir); err != nil || !info.IsDir() {
@@ -398,28 +342,20 @@ func parseTools(baseDir string, days int, projectFilter string) (*ToolResult, er
 
 	matchedSlug := resolveProjectSlug(projectsDir, projectFilter)
 	if projectFilter != "" && matchedSlug == "" {
-		return &ToolResult{
-			ToolCounts:     make(map[string]int),
-			ToolErrors:     make(map[string]int),
-			SkillCounts:    make(map[string]int),
-			AgentCounts:    make(map[string]int),
-			AgentTotalTime: make(map[string]time.Duration),
-			ToolProjects:   make(map[string]map[string]bool),
-			SkillProjects:  make(map[string]map[string]bool),
-			AgentProjects:  make(map[string]map[string]bool),
-			ToolSessions:   make(map[string]bool),
-			AgentSessions:  make(map[string]bool),
-			SkillSessions:  make(map[string]bool),
-		}, nil
+		return newToolResult(), nil
 	}
 
 	col := newToolCollector()
-	w := &toolWalker{
+	w := &dirWalker{
 		projectsDir: projectsDir,
 		matchedSlug: matchedSlug,
-		hasCutoff:   days > 0,
+		hasCutoff:   hasCutoff,
 		cutoff:      cutoff,
-		col:         col,
+		onFile: func(path, projectSlug, sessionID string) {
+			if _, fErr := parseToolFile(path, cutoff, hasCutoff, projectSlug, sessionID, col); fErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not read %s: %v\n", path, fErr)
+			}
+		},
 	}
 
 	if err := filepath.WalkDir(projectsDir, w.walk); err != nil {

--- a/tools_test.go
+++ b/tools_test.go
@@ -370,6 +370,20 @@ func TestParseSkillListing_NamespacedSkills(t *testing.T) {
 	}
 }
 
+func TestParseSkillListing_BareNames(t *testing.T) {
+	content := "- review-diff: Use when reviewing a diff\n- optimize-tests\n- create-prd\n- superpowers:execute-plan\n- mysql:mysql-lint: Analyze MySQL queries"
+	got := parseSkillListing(content)
+	want := []string{"review-diff", "optimize-tests", "create-prd", "superpowers:execute-plan", "mysql:mysql-lint"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d skills, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("skill[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestParseSkillListing_Empty(t *testing.T) {
 	got := parseSkillListing("")
 	if len(got) != 0 {

--- a/walker.go
+++ b/walker.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// fileVisitor is invoked once per matched .jsonl file with its project slug and
+// session id (the latter derived from the path; empty for top-level files).
+type fileVisitor func(path, projectSlug, sessionID string)
+
+// dirWalker walks a Claude Code projects directory, applying the project-slug
+// filter and modtime cutoff, and calls onFile for each surviving .jsonl file.
+type dirWalker struct {
+	projectsDir string
+	matchedSlug string
+	hasCutoff   bool
+	cutoff      time.Time
+	onFile      fileVisitor
+	totalFiles  int
+}
+
+func (w *dirWalker) walk(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+		return nil
+	}
+
+	if d.IsDir() {
+		if path == w.projectsDir {
+			return nil
+		}
+		if w.matchedSlug != "" {
+			rel, _ := filepath.Rel(w.projectsDir, path)
+			slug := strings.SplitN(rel, string(filepath.Separator), 2)[0]
+			if slug != w.matchedSlug {
+				return fs.SkipDir
+			}
+		}
+		return nil
+	}
+
+	if !strings.HasSuffix(path, ".jsonl") {
+		return nil
+	}
+
+	if w.hasCutoff {
+		if info, err := d.Info(); err == nil && info.ModTime().Before(w.cutoff) {
+			return nil
+		}
+	}
+
+	rel, err := filepath.Rel(w.projectsDir, path)
+	if err != nil {
+		return nil
+	}
+	parts := strings.SplitN(rel, string(filepath.Separator), 2)
+	projectSlug := parts[0]
+
+	sessionID := ""
+	if len(parts) > 1 {
+		sessionParts := strings.SplitN(parts[1], string(filepath.Separator), 2)
+		sessionID = strings.TrimSuffix(sessionParts[0], ".jsonl")
+	}
+
+	w.totalFiles++
+	w.onFile(path, projectSlug, sessionID)
+	return nil
+}


### PR DESCRIPTION
## Summary

Maintainability pass from a full-repo code review, plus one behavioral fix. Three commits, reviewable independently.

### `refactor: unify log/tool walkers and drop test-only shims`
- Collapse the two near-identical projects-directory walkers into a single `dirWalker` (`walker.go`) driven by a per-file callback.
- Extract `localMidnightCutoff` and `hasJSONType` helpers, removing the cutoff and `"type"` byte-check duplication across `parser.go`/`tools.go`.
- Add `newParseResult`/`newToolResult` constructors for the repeated map initialization.
- Remove the `formatFiveHourUsage` and `formatStatusline` shims that existed only for tests; tests now call the real functions.

### `fix: count skills listed without a description in tool analytics`
Skill-listing lines without a `": description"` suffix (e.g. `- optimize-tests`) were skipped, so those skills never entered the available-skills set and were misreported as unused. The trimmed line is now used as the skill name when no separator is present.

### `refactor: collapse repeated sort+topN logic into generic sortAndTrim`
Route the ~13 sort-and-truncate sites in `format.go` through one generic `sortAndTrim` helper instead of hand-rolling `sort.Slice` + topN guards at each call. Also consolidates the daily/monthly and project/branch breakdown printers (`printPeriodBreakdown`, `printBreakdownGroup`) and the JSON daily/monthly rows (`jsonPeriodRow`).

## Verification
`make check` green (vet, gofmt, `go test -race`, golangci-lint, gocyclo). New tests cover the breakdown print paths (previously only exercised via the removed shims), bare skill-name parsing, and the JSON daily/monthly builders.
