### PR TITLE
feat: add worktree statusline segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,10 @@ Available segments:
 | `lines` | `📝 +N -N` | both zero | emoji |
 | `duration` | `⏱️ Xm` | zero | emoji |
 | `cwd` | `📁 dirname` | empty | emoji |
-| `worktree` | `🌳 worktree-name` | not in a linked worktree | emoji |
+| `worktree` | `🌳 worktree-name` | not in a linked worktree (submodules don't count) | emoji |
 | `version` | `🏷️ X.Y.Z` | empty | emoji |
 
 **`separator`** — string between segments (default: `" · "`).
-
-**`worktree`** — shows the directory name of the linked [git worktree](https://git-scm.com/docs/git-worktree) the session is running in, and stays hidden in the main checkout, so it only draws attention when you're somewhere other than where you usually are. Submodules are not worktrees and never trigger it. Pair it with `branch` when several worktrees share a repo:
-
-```text
-💸 $1.23 session · 🌿 feature/auth · 🌳 repo-feature-auth
-```
 
 **`segment_options`** — per-segment overrides. `emoji` replaces the default icon (for `5h`/`7d`, replaces the dynamic 🔋/🪫). `label` replaces trailing text (only on segments marked above).
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,16 @@ Available segments:
 | `lines` | `📝 +N -N` | both zero | emoji |
 | `duration` | `⏱️ Xm` | zero | emoji |
 | `cwd` | `📁 dirname` | empty | emoji |
+| `worktree` | `🌳 worktree-name` | not in a linked worktree | emoji |
 | `version` | `🏷️ X.Y.Z` | empty | emoji |
 
 **`separator`** — string between segments (default: `" · "`).
+
+**`worktree`** — shows the directory name of the linked [git worktree](https://git-scm.com/docs/git-worktree) the session is running in, and stays hidden in the main checkout, so it only draws attention when you're somewhere other than where you usually are. Submodules are not worktrees and never trigger it. Pair it with `branch` when several worktrees share a repo:
+
+```text
+💸 $1.23 session · 🌿 feature/auth · 🌳 repo-feature-auth
+```
 
 **`segment_options`** — per-segment overrides. `emoji` replaces the default icon (for `5h`/`7d`, replaces the dynamic 🔋/🪫). `label` replaces trailing text (only on segments marked above).
 

--- a/statusline_config.go
+++ b/statusline_config.go
@@ -79,6 +79,7 @@ var segmentRegistry = map[string]segmentRenderer{
 	"lines":        renderLines,
 	"duration":     renderDuration,
 	"cwd":          renderCwd,
+	"worktree":     renderWorktree,
 	"version":      renderVersion,
 }
 
@@ -271,16 +272,33 @@ func renderBranch(ctx *StatuslineContext) string {
 	return fmt.Sprintf("%s %s", emoji, ctx.Branch)
 }
 
-func renderCwd(ctx *StatuslineContext) string {
-	cwd := ctx.Input.Cwd
-	if cwd == "" {
-		cwd = ctx.Input.Workspace.CurrentDir
+// statuslineCwd returns the session's working directory, preferring the explicit
+// cwd and falling back to the workspace directory.
+func statuslineCwd(ctx *StatuslineContext) string {
+	if ctx.Input.Cwd != "" {
+		return ctx.Input.Cwd
 	}
+	return ctx.Input.Workspace.CurrentDir
+}
+
+func renderCwd(ctx *StatuslineContext) string {
+	cwd := statuslineCwd(ctx)
 	if cwd == "" {
 		return ""
 	}
 	emoji := segmentEmoji("cwd", "📁", ctx.Options)
 	return fmt.Sprintf("%s %s", emoji, filepath.Base(cwd))
+}
+
+// renderWorktree resolves the worktree from the filesystem on demand — cheap,
+// and assembleStatusline only reaches renderers the user actually configured.
+func renderWorktree(ctx *StatuslineContext) string {
+	name := detectWorktree(statuslineCwd(ctx))
+	if name == "" {
+		return ""
+	}
+	emoji := segmentEmoji("worktree", "🌳", ctx.Options)
+	return fmt.Sprintf("%s %s", emoji, name)
 }
 
 func renderVersion(ctx *StatuslineContext) string {

--- a/statusline_config.go
+++ b/statusline_config.go
@@ -272,8 +272,6 @@ func renderBranch(ctx *StatuslineContext) string {
 	return fmt.Sprintf("%s %s", emoji, ctx.Branch)
 }
 
-// statuslineCwd returns the session's working directory, preferring the explicit
-// cwd and falling back to the workspace directory.
 func statuslineCwd(ctx *StatuslineContext) string {
 	if ctx.Input.Cwd != "" {
 		return ctx.Input.Cwd

--- a/worktree.go
+++ b/worktree.go
@@ -23,13 +23,13 @@ func detectWorktree(dir string) string {
 		info, err := os.Stat(gitPath)
 		switch {
 		case err != nil:
-			// No marker at this level — keep walking up.
+			// No marker here — keep walking up.
 		case info.IsDir():
-			return "" // main checkout
+			return ""
 		case pointsAtWorktree(gitPath):
 			return filepath.Base(dir)
 		default:
-			return "" // submodule, or a .git file we don't recognize
+			return ""
 		}
 
 		parent := filepath.Dir(dir)
@@ -43,7 +43,13 @@ func detectWorktree(dir string) string {
 
 // pointsAtWorktree reports whether a .git file's gitdir target names a linked
 // worktree ("…/worktrees/<name>") rather than a submodule ("…/modules/<name>").
-// The target may be absolute or relative, so only its last two elements matter.
+//
+// The path shape alone isn't proof — any directory could sit under something
+// called "worktrees" — so the target is confirmed by the "gitdir" backlink git
+// writes inside every linked worktree's admin directory and inside no
+// submodule's. Checking the backlink rather than the grandparent's name keeps
+// worktrees of a bare repo working, where the target is "<repo>.git/worktrees/
+// <name>" and there is no ".git" element at all.
 func pointsAtWorktree(gitFile string) bool {
 	data, err := os.ReadFile(gitFile)
 	if err != nil {
@@ -53,6 +59,16 @@ func pointsAtWorktree(gitFile string) bool {
 	if !ok {
 		return false
 	}
-	parts := strings.Split(filepath.ToSlash(strings.TrimSpace(target)), "/")
-	return len(parts) >= 2 && parts[len(parts)-2] == "worktrees"
+	target = strings.TrimSpace(target)
+	parts := strings.Split(filepath.ToSlash(target), "/")
+	if len(parts) < 2 || parts[len(parts)-2] != "worktrees" {
+		return false
+	}
+
+	// A relative target resolves against the directory holding the .git file.
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(gitFile), target)
+	}
+	info, err := os.Stat(filepath.Join(target, "gitdir"))
+	return err == nil && !info.IsDir()
 }

--- a/worktree.go
+++ b/worktree.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// worktreeWalkLimit bounds the climb toward the filesystem root while looking
+// for a repository marker, so an unusually deep cwd can't stall the statusline.
+const worktreeWalkLimit = 64
+
+// detectWorktree returns the directory name of the linked git worktree holding
+// dir, or "" when dir sits in a main checkout, a submodule, or outside a
+// repository. Detection is best-effort — any error yields "", never a failure.
+//
+// A linked worktree marks its root with a .git *file* pointing at
+// "<repo>/.git/worktrees/<name>", while a main checkout has a .git directory.
+// Submodules also use a .git file, but point into "<repo>/.git/modules/<name>".
+func detectWorktree(dir string) string {
+	for i := 0; i < worktreeWalkLimit && dir != ""; i++ {
+		gitPath := filepath.Join(dir, ".git")
+		info, err := os.Stat(gitPath)
+		switch {
+		case err != nil:
+			// No marker at this level — keep walking up.
+		case info.IsDir():
+			return "" // main checkout
+		case pointsAtWorktree(gitPath):
+			return filepath.Base(dir)
+		default:
+			return "" // submodule, or a .git file we don't recognize
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached the filesystem root
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// pointsAtWorktree reports whether a .git file's gitdir target names a linked
+// worktree ("…/worktrees/<name>") rather than a submodule ("…/modules/<name>").
+// The target may be absolute or relative, so only its last two elements matter.
+func pointsAtWorktree(gitFile string) bool {
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		return false
+	}
+	target, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+	if !ok {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(strings.TrimSpace(target)), "/")
+	return len(parts) >= 2 && parts[len(parts)-2] == "worktrees"
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newWorktree builds a linked worktree named name under a temp dir and returns
+// its root — the same layout `git worktree add` produces.
+func newWorktree(t *testing.T, name string) string {
+	t.Helper()
+	base := t.TempDir()
+
+	repo := filepath.Join(base, "repo")
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "worktrees", name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := filepath.Join(base, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitFile := "gitdir: " + filepath.Join(gitDir, "worktrees", name) + "\n"
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte(gitFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// newGitFileDir writes a directory whose .git is a file with the given content.
+func newGitFileDir(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestDetectWorktree_LinkedWorktree(t *testing.T) {
+	root := newWorktree(t, "feature-auth")
+	if got := detectWorktree(root); got != "feature-auth" {
+		t.Errorf("got %q, want feature-auth", got)
+	}
+}
+
+func TestDetectWorktree_SubdirectoryOfWorktree(t *testing.T) {
+	root := newWorktree(t, "hotfix")
+	nested := filepath.Join(root, "cmd", "server")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := detectWorktree(nested); got != "hotfix" {
+		t.Errorf("got %q, want hotfix", got)
+	}
+}
+
+func TestDetectWorktree_MainCheckout(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := detectWorktree(dir); got != "" {
+		t.Errorf("got %q, want empty for a main checkout", got)
+	}
+}
+
+// A worktree nested inside its own main checkout must resolve to the worktree,
+// not stop at the parent repo — the layout Claude Code's .claude/worktrees uses.
+func TestDetectWorktree_NestedInsideMainCheckout(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git", "worktrees", "perf"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(repo, ".claude", "worktrees", "perf")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitFile := "gitdir: " + filepath.Join(repo, ".git", "worktrees", "perf") + "\n"
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte(gitFile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := detectWorktree(root); got != "perf" {
+		t.Errorf("got %q, want perf", got)
+	}
+}
+
+func TestDetectWorktree_Submodule(t *testing.T) {
+	dir := newGitFileDir(t, "gitdir: /repo/.git/modules/vendor/lib\n")
+	if got := detectWorktree(dir); got != "" {
+		t.Errorf("got %q, want empty for a submodule", got)
+	}
+}
+
+func TestDetectWorktree_RelativeGitdir(t *testing.T) {
+	dir := newGitFileDir(t, "gitdir: ../repo/.git/worktrees/rel\n")
+	if got := detectWorktree(dir); got != filepath.Base(dir) {
+		t.Errorf("got %q, want %q", got, filepath.Base(dir))
+	}
+}
+
+func TestDetectWorktree_NotARepo(t *testing.T) {
+	if got := detectWorktree(t.TempDir()); got != "" {
+		t.Errorf("got %q, want empty outside a repo", got)
+	}
+}
+
+func TestDetectWorktree_EmptyDir(t *testing.T) {
+	if got := detectWorktree(""); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestDetectWorktree_MalformedGitFile(t *testing.T) {
+	for _, content := range []string{"", "not a gitdir line\n", "gitdir:\n", "gitdir: worktrees\n"} {
+		dir := newGitFileDir(t, content)
+		if got := detectWorktree(dir); got != "" {
+			t.Errorf("content %q: got %q, want empty", content, got)
+		}
+	}
+}
+
+func TestRenderWorktree(t *testing.T) {
+	root := newWorktree(t, "feature-auth")
+
+	input := &StatuslineInput{Cwd: root}
+	ctx := &StatuslineContext{Input: input}
+	if got := renderWorktree(ctx); got != "🌳 feature-auth" {
+		t.Errorf("got %q, want 🌳 feature-auth", got)
+	}
+}
+
+func TestRenderWorktree_EmojiOverride(t *testing.T) {
+	root := newWorktree(t, "feature-auth")
+
+	ctx := &StatuslineContext{
+		Input:   &StatuslineInput{Cwd: root},
+		Options: map[string]SegmentOptions{"worktree": {Emoji: "🪵"}},
+	}
+	if got := renderWorktree(ctx); got != "🪵 feature-auth" {
+		t.Errorf("got %q, want 🪵 feature-auth", got)
+	}
+}
+
+func TestRenderWorktree_FallsBackToWorkspaceDir(t *testing.T) {
+	root := newWorktree(t, "docs")
+
+	input := &StatuslineInput{}
+	input.Workspace.CurrentDir = root
+	if got := renderWorktree(&StatuslineContext{Input: input}); got != "🌳 docs" {
+		t.Errorf("got %q, want 🌳 docs", got)
+	}
+}
+
+func TestRenderWorktree_HidesOutsideWorktree(t *testing.T) {
+	ctx := &StatuslineContext{Input: &StatuslineInput{Cwd: t.TempDir()}}
+	if got := renderWorktree(ctx); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestAssembleStatusline_WorktreeSegment(t *testing.T) {
+	root := newWorktree(t, "feature-auth")
+
+	ctx := &StatuslineContext{Input: &StatuslineInput{Cwd: root}}
+	got := assembleStatusline([]string{"cwd", "worktree"}, " · ", ctx)
+	want := "📁 feature-auth · 🌳 feature-auth"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -6,26 +6,34 @@ import (
 	"testing"
 )
 
+// linkWorktree wires a worktree root to its admin directory the way
+// `git worktree add` does: a .git file at the root naming target, and the
+// "gitdir" backlink git keeps inside the admin directory pointing back at it.
+func linkWorktree(t *testing.T, root, adminDir, target string) {
+	t.Helper()
+	if err := os.MkdirAll(adminDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitFile := filepath.Join(root, ".git")
+	if err := os.WriteFile(gitFile, []byte("gitdir: "+target+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(adminDir, "gitdir"), []byte(gitFile+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // newWorktree builds a linked worktree named name under a temp dir and returns
 // its root — the same layout `git worktree add` produces.
 func newWorktree(t *testing.T, name string) string {
 	t.Helper()
 	base := t.TempDir()
-
-	repo := filepath.Join(base, "repo")
-	gitDir := filepath.Join(repo, ".git")
-	if err := os.MkdirAll(filepath.Join(gitDir, "worktrees", name), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
+	adminDir := filepath.Join(base, "repo", ".git", "worktrees", name)
 	root := filepath.Join(base, name)
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	gitFile := "gitdir: " + filepath.Join(gitDir, "worktrees", name) + "\n"
-	if err := os.WriteFile(filepath.Join(root, ".git"), []byte(gitFile), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	linkWorktree(t, root, adminDir, adminDir)
 	return root
 }
 
@@ -71,19 +79,52 @@ func TestDetectWorktree_MainCheckout(t *testing.T) {
 // not stop at the parent repo — the layout Claude Code's .claude/worktrees uses.
 func TestDetectWorktree_NestedInsideMainCheckout(t *testing.T) {
 	repo := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(repo, ".git", "worktrees", "perf"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	adminDir := filepath.Join(repo, ".git", "worktrees", "perf")
 	root := filepath.Join(repo, ".claude", "worktrees", "perf")
-	if err := os.MkdirAll(root, 0o755); err != nil {
+	linkWorktree(t, root, adminDir, adminDir)
+
+	// Start below the worktree root, so the walk has to stop at the worktree's
+	// .git file rather than continue to the enclosing checkout's .git directory.
+	nested := filepath.Join(root, "internal", "cache")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	gitFile := "gitdir: " + filepath.Join(repo, ".git", "worktrees", "perf") + "\n"
-	if err := os.WriteFile(filepath.Join(root, ".git"), []byte(gitFile), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if got := detectWorktree(root); got != "perf" {
+	if got := detectWorktree(nested); got != "perf" {
 		t.Errorf("got %q, want perf", got)
+	}
+}
+
+// A worktree of a bare repo has no ".git" element in its target at all — the
+// admin directory sits directly under the bare repo.
+func TestDetectWorktree_BareRepoParent(t *testing.T) {
+	base := t.TempDir()
+	adminDir := filepath.Join(base, "repo.git", "worktrees", "release")
+	root := filepath.Join(base, "release")
+	linkWorktree(t, root, adminDir, adminDir)
+	if got := detectWorktree(root); got != "release" {
+		t.Errorf("got %q, want release", got)
+	}
+}
+
+// A target that merely happens to sit under a directory named "worktrees" is
+// not a worktree — git's backlink is absent.
+func TestDetectWorktree_WorktreesLookalike(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "worktrees", "foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(base, "project")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: ../worktrees/foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := detectWorktree(dir); got != "" {
+		t.Errorf("got %q, want empty for a lookalike target", got)
 	}
 }
 
@@ -95,9 +136,12 @@ func TestDetectWorktree_Submodule(t *testing.T) {
 }
 
 func TestDetectWorktree_RelativeGitdir(t *testing.T) {
-	dir := newGitFileDir(t, "gitdir: ../repo/.git/worktrees/rel\n")
-	if got := detectWorktree(dir); got != filepath.Base(dir) {
-		t.Errorf("got %q, want %q", got, filepath.Base(dir))
+	base := t.TempDir()
+	adminDir := filepath.Join(base, "repo", ".git", "worktrees", "rel")
+	root := filepath.Join(base, "rel")
+	linkWorktree(t, root, adminDir, "../repo/.git/worktrees/rel")
+	if got := detectWorktree(root); got != "rel" {
+		t.Errorf("got %q, want rel", got)
 	}
 }
 


### PR DESCRIPTION
## TL;DR

Nothing in the statusline tells you that a session is running in a linked git worktree rather than the main checkout — `branch` comes from the transcript and `cwd` is a bare directory name, so several checkouts of the same repo look alike. This adds a `worktree` segment that shows the worktree's directory name and hides itself in the main checkout.

```text
💸 $1.23 session · 💭 45% ctx · 🌿 perf/tina-mdx · 🌳 perf-tina-mdx-sanitize-url
```

## How

Detection is filesystem-only, no `git` subprocess. A linked worktree roots itself with a `.git` **file** pointing at `<repo>/.git/worktrees/<name>`, while a main checkout has a `.git` **directory**. `detectWorktree` walks up from the session cwd until it finds either, so a cwd deep inside a worktree still resolves.